### PR TITLE
:sparkles: New filter constraint `containsIn`

### DIFF
--- a/src/app/components/table/table.ts
+++ b/src/app/components/table/table.ts
@@ -1203,6 +1203,29 @@ export class Table implements OnInit, AfterContentInit {
             }
 
             return value > filter;
+        },
+
+        containsIn: function (value, filter) {
+            if (filter === undefined || filter === null || filter.length === 0) {
+                return true;
+            }
+            if (value === undefined || value === null) {
+                return false;
+            }
+            for (let _i = 0; _i < filter.length; _i++) {
+                if (filter[_i] === undefined || filter[_i] === null || (typeof filter[_i] === 'string' && filter[_i].trim() === '')) {
+                    return true;
+                }
+                if (value === undefined || value === null) {
+                    return false;
+                }
+                const _regExp = new RegExp('\\b' + filter[_i].toLowerCase() + '\\b');
+                const _result = _regExp.test(value.toString().toLowerCase());
+                if (_result) {
+                    return _result;
+                }
+            }
+            return false;
         }
     }
 


### PR DESCRIPTION
This new constraints allow to filter with a mutliselect over several values (as string for now) instead of only one.
Rule is as following : If at least one element of the selected list is present in the cell return true (keep the row), else return false (exclude the row)
Here is a small example on how it works in the html

```html
<p-table #dt [value]="entities" emptyMessage="empty">
  <ng-template pTemplate="header">
    <tr>
      <th>
        <p-multiSelect 
          [options]="groups"
          defaultLabel="Tous les groupes"
          (onChange)="dt.filter($event.value, 'groups', 'containsIn')">
        </p-multiSelect>
      </th>
    </tr>
  </ng-template>
  <ng-template let-rowData pTemplate="body">
    <tr>
      <td>
        {{rowData.['groups']}}
      </td>
    </tr>
  </ng-template>
</p-table>
```

And the following explaining the result on the interfaces

|  Groups  |
|  ------  |
|  g1      |
|  g1, g2  |
|  g2      |
|  g3      |
|  g4, g3  |

[x] g1

|  Groups  |
|  ------  |
|  g1      |
|  g1, g2  |

[x] g1
[x] g4

|  Groups  |
|  ------  |
|  g1      |
|  g1, g2  |
|  g4, g3  |

###Defect Fixes
When submitting a PR, please also create an issue documenting the error.

###Feature Requests
Due to company policy, we are unable to accept feature request PRs with significant changes as such cases has to be implemented by our team following our own processes.